### PR TITLE
Add Russian language translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Currently, the theme is delivered with support for:
 - French (fr)
 - Dutch (nl)
 - Spanish (es)
+- Russian (ru)
 
 If you would like to use one the languages listed above, simply set `language`
 to the desired language (e.g., `fr`) in `_config.yml`.
@@ -200,7 +201,7 @@ Add you Google Analytics or Baidu Tongji `tracking_id` to the `_config.yml`.
 google_analytics:
   enabled: true
   id: 'UA-49627206-1'
-  
+
 baidu_analytics:
   enabled: true
   id: 2e6da3c375c8a87f5b664cea6d4cb29c

--- a/languages/ru.yml
+++ b/languages/ru.yml
@@ -1,0 +1,38 @@
+nav:
+  home: Главная
+  about: Обо мне
+  articles: Блог
+  projects: Проекты
+  search: Искать
+
+footer:
+  copyright: ' '
+
+index:
+  find_me_on: 'Свяжитесь со мной:'
+  enum_comma: ','
+  enum_and: и
+  articles: Блог
+  projects: Проекты
+
+post:
+  desktop:
+    previous: Предыдущая запись
+    next: Следующая запись
+    back_to_top: В начало
+    share: Поделиться
+  mobile:
+    menu: Меню
+    toc: Оглавление
+    back_to_top: В начало
+    share: Поделиться
+
+search:
+  search: Искать...
+  no_results: Ничего не найдено.
+
+pagination:
+  page: Страница %d из %d
+
+comments:
+  no_js: Включите JavaScript, чтобы читать комментарии.


### PR DESCRIPTION
This should get you started! The "copyright" notice is left empty intentionally — we don't have a suitable term, and a plain copyright sign is fairy common.
Some side notes:

- The included Meslo font comes with cyrillic support, which increases load time for (the majority of sites) that don't use it.
- YYYY-MM-DD date format is uncommon in Russia, mostly DD.MM.YYYY is used.

I'm new to hexo though, can't seem a to find a way of overriding these from the locale file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/probberechts/hexo-theme-cactus/87)
<!-- Reviewable:end -->
