### PR TITLE
Added tagcloud option to the index page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,7 +21,7 @@ nav:
 
 
 # Links to your social media accounts.
-# The keys should correspond to Fontawesome icon names 
+# The keys should correspond to Fontawesome icon names
 # (see https://fontawesome.com/icons?d=gallery&s=brands);
 # only 'mail' is an exception.
 social_links:
@@ -31,6 +31,11 @@ social_links:
   linkedin: /
   mail: mailto:name@email.com
 
+# Customize the overview with displaying a tagcloud on the index page.
+# Options:
+#   - show_all_tags: whether to enable the tagcloud.
+tags_overview:
+  show_all_tags: true
 
 # Customize the overview with the most recent blog posts on the index page.
 # Options:
@@ -68,7 +73,7 @@ logo:
 # Options:
 #   - url: where the icon can be found
 #   - gravatar: whether to create a favicon from your Gravatar
-favicon: 
+favicon:
   desktop:
     url: /images/favicon.ico
     gravatar: false
@@ -100,7 +105,7 @@ page_width: 48
 rss: false
 
 # Turn your web pages into graph objects (see http://ogp.me).
-open_graph: 
+open_graph:
   fb_app_id:
   fb_admins:
   twitter_id:
@@ -112,12 +117,12 @@ open_graph:
 ##############################################################################
 
 # Fill in your Disqus Comments Shortname to enable Disqus comments.
-disqus: 
+disqus:
   enabled: false
   shortname: cactus-1
 
 # Fill in your Google Analytics tracking ID to enable Google Analytics.
-google_analytics: 
+google_analytics:
   enabled: false
   id: UA-86660611-1
 

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -14,6 +14,7 @@ index:
   enum_and: and
   articles: Writing
   projects: Projects
+  all_tags: Tags
 
 post:
   desktop:

--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -17,9 +17,9 @@
             <i class="fab fa-<%= link %>"></i><!--
       ---></a><!--
     ---><% } %><!--
-    ---><%= ( nb_links > 0 && i < nb_links-1 ? 
-            ( i == nb_links-2 ? ' '+__('index.enum_and')+' ' 
-            : __('index.enum_comma')+' ' ) 
+    ---><%= ( nb_links > 0 && i < nb_links-1 ?
+            ( i == nb_links-2 ? ' '+__('index.enum_and')+' '
+            : __('index.enum_comma')+' ' )
             : '.' ) %>
         <% i+=1 %>
       <% } %>
@@ -57,5 +57,14 @@
       </li>
     <% } %>
   </ul>
+</section>
+<% } %>
+
+<% if (theme.tags_overview.show_all_tags && site.tags.length) { %>
+<section id="tags">
+  <span class="h1"><%= __('index.all_tags') %></a></span>
+    <div class="widget tagcloud">
+      <%- tagcloud() %>
+    </div>
 </section>
 <% } %>


### PR DESCRIPTION
I quite missed that feature in this awesome theme :). 

Added a new setting for the config to display all tags on the index page. 
This will use the hexo helperscript tagcloud().

Preview:
![tagcloud_cactus_example](https://i.imgur.com/Tpll44s.png)