### PR TITLE
add mathjax support for single post

### DIFF
--- a/layout/_partial/mathjax.ejs
+++ b/layout/_partial/mathjax.ejs
@@ -1,0 +1,15 @@
+<!-- mathjax config -->
+<script type="text/x-mathjax-config">
+MathJax.Hub.Config({
+    jax: ["input/TeX", "output/HTML-CSS"],
+    tex2jax: {
+        inlineMath: [ ['$', '$'] ],
+        displayMath: [ ['$$', '$$']],
+        processEscapes: true,
+        skipTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code']
+    },
+    messageStyle: "none",
+    "HTML-CSS": { preferredFont: "TeX", availableFonts: ["STIX","TeX"] }
+});
+</script>
+<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>

--- a/layout/post.ejs
+++ b/layout/post.ejs
@@ -15,3 +15,7 @@
   </div>
 </article>
 <%- partial('_partial/comments') %>
+
+<% if (page['mathjax']){ %>
+<%- partial('_partial/mathjax') %>
+<% } %>


### PR DESCRIPTION
Add support for [mathjax](https://www.mathjax.org/) in a single post. 
Able to display formulas in the post.
Only need to set `mathjax: true`  in the post head.
