### PR TITLE
reblob homepage link

### DIFF
--- a/layout/_partial/post/title.ejs
+++ b/layout/_partial/post/title.ejs
@@ -1,4 +1,8 @@
 <% if (index) { %>
+    <% if (post.reblog && post.rebloglink) { %>
+        <a class="icon" href="<%- url_for(post.rebloglink) %>" target="_blank" itemprop="url">
+        <i class="fas fa-link"></i></a>
+    <% } %>
     <% if (post.link) { %>
         <a class="<%= class_name %>" href="<%- url_for(post.link) %>" target="_blank" itemprop="url"><%= post.title %></a>
     <% } else if (post.title) { %>


### PR DESCRIPTION
I don't know if this can be interesting. I'm adding two new properties to the post that, if valorised, will display an icon with the link at the original post in homepage.
This can be used for a reblog or a _link post_ in which the post on the current blog is only a comment of the original one.

Maybe I'll do some other changes in the post page to use the two new properties.