### PR TITLE
Move css and scripts partials inside the body

### DIFF
--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -15,7 +15,7 @@
         <% } %>
         <%- partial('_partial/footer') %>
     </div>
+    <%- partial('_partial/styles') %>
+    <%- partial('_partial/scripts') %>
 </body>
 </html>
-<%- partial('_partial/styles') %>
-<%- partial('_partial/scripts') %>


### PR DESCRIPTION
This will fix the "Stray start tag" from the W3C validator.

Fixes #147 