### PR TITLE
fix body height

### DIFF
--- a/source/css/style.styl
+++ b/source/css/style.styl
@@ -19,7 +19,7 @@ html
   -ms-text-size-adjust: 100%
 
 body
-  height: 100%
+  min-height: 100%
   background-color: $color-background
   color: $color-text
   font-display: swap // @stylint ignore


### PR DESCRIPTION
`height: 100%` means body is always as long as browser. So when content is longer, the background won't extend to as long as the content. Changing it to `min-height: 100%` makes this happen, and also makes sure the background is always at least as long as the browser, even when the content does not fill one screen-length.