### PR TITLE
Fix <hr> size

### DIFF
--- a/source/css/_extend.styl
+++ b/source/css/_extend.styl
@@ -47,6 +47,7 @@ $base-style
 
   hr
     border: 1px dashed $color-accent-3
+    margin: 0
 
   strong
     font-weight: bold


### PR DESCRIPTION
On my chrome \<hr\> is rendered with zero size and 50% on both left and right, making it appears as a dot. The added line forces the rule to extends fully both sides in its containing element.