### PR TITLE
fix overflow

### DIFF
--- a/source/css/style.styl
+++ b/source/css/style.styl
@@ -46,6 +46,9 @@ body
   code
     hyphens(manual)
 
+  article
+    word-break: break-word
+
   a
     color: $color-text
     text-decoration: none


### PR DESCRIPTION
when the length of words in element `<a>` under element `<li>` is too long, there is no word-break.

I thought that is needed to fix.

PC:

![pc](https://user-images.githubusercontent.com/7395833/53726775-ad55fe80-3ea9-11e9-8aaa-dab548220d38.png)

Mobile:
![mobile](https://user-images.githubusercontent.com/7395833/53726780-af1fc200-3ea9-11e9-8e09-df2331ba34b7.png)
