### PR TITLE
Fix error when gravatar is not present

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -14,21 +14,21 @@
     <%- meta(page) %>
     <% if (theme.favicon) { %>
         <% if (theme.favicon.desktop) { %>
-          <% if (theme.gravatar.email && theme.favicon.desktop.gravatar) { %>
+          <% if (theme.gravatar && theme.gravatar.email && theme.favicon.desktop.gravatar) { %>
               <link rel="shortcut icon" href="<%= gravatar(theme.gravatar.email, 16) %>">
           <% } else { %>
               <link rel="shortcut icon" href="<%= url_for(theme.favicon.desktop.url) %>">
           <% } %>
         <% } %>
         <% if (theme.favicon.android) { %>
-          <% if (theme.gravatar.email && theme.favicon.android.gravatar) { %>
+          <% if (theme.gravatar && theme.gravatar.email && theme.favicon.android.gravatar) { %>
             <link rel="icon" type="image/png" href="<%= gravatar(theme.gravatar.email, 192) %>" sizes="192x192">
           <% } else { %>
             <link rel="icon" type="image/png" href="<%= url_for(theme.favicon.android.url) %>" sizes="192x192">
           <% } %>
         <% } %>
         <% if (theme.favicon.apple) { %>
-          <% if (theme.gravatar.email && theme.favicon.apple.gravatar) { %>
+          <% if (theme.gravatar && theme.gravatar.email && theme.favicon.apple.gravatar) { %>
             <link rel="apple-touch-icon" sizes="180x180" href="<%= gravatar(theme.gravatar.email, 180) %>">
           <% } else { %>
             <link rel="apple-touch-icon" sizes="180x180" href="<%= url_for(theme.favicon.apple.url) %>">

--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -1,7 +1,7 @@
 <header id="header">
   <a href="<%- url_for("/") %>">
   <% if (theme.logo && theme.logo.enabled) { %>
-    <% if (theme.gravatar.email && theme.logo.gravatar) { %>
+    <% if (theme.gravatar && theme.gravatar.email && theme.logo.gravatar) { %>
       <div id="logo" style="background-image: url(<%- gravatar(theme.gravatar.email) %>);"></div>
     <% } else { %>
       <div id="logo" style="background-image: url(<%- url_for(theme.logo.url) %>);"></div>


### PR DESCRIPTION
An error will be raised when `gravatar` area is not present in `_config.yml` of the theme. This PR check for `theme.gravatar` before invoking `theme.gravatar.email` to prevent this.