### PR TITLE
fix: links to cross origin destinations are unsafe

### DIFF
--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -9,11 +9,11 @@
       <% var i = 0 %>
       <% for(var link in theme.social_links) { %>
         <% if (link == 'mail') { %>
-          <a class="icon" target="_blank" href="<%- theme.social_links[link] %>">
+          <a class="icon" target="_blank" rel="noopener" href="<%- theme.social_links[link] %>">
             <i class="fas fa-envelope"></i><!--
       ---></a><!--
       ---><% } else { %>
-          <a class="icon" target="_blank" href="<%- url_for(theme.social_links[link]) %>">
+          <a class="icon" target="_blank" rel="noopener" href="<%- url_for(theme.social_links[link]) %>">
             <i class="fab fa-<%= link %>"></i><!--
       ---></a><!--
     ---><% } %><!--


### PR DESCRIPTION
Social links are cross-origin, and rel="noopener"` or `rel="noreferrer"` must be added to any external links to improve performance and prevent security vulnerabilities.