### PR TITLE
Add logo grayout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ colorscheme: light
 Alternatively, you can easily create your own color scheme by creating a new
 file in `source/css/_colors`.
 
+### Logo
+
+By default there is a grayout effect on logo. You can turn it off by add `logo-grayout` option in the `_config.yml`:
+
+```yml
+logo-grayout: false
+```
 
 ### Navigation
 

--- a/_config.yml
+++ b/_config.yml
@@ -76,6 +76,9 @@ logo:
   height: 50
   url: /images/logo.png
   gravatar: false
+# Whether to grayout (true) the logo or keep original (false)
+# if true (by default), there will be a hover effect on header
+logo-grayout: true
 
 # Customize the favicons.
 # Cactus supports a limited set of the three most important icons:

--- a/source/css/_partial/header.styl
+++ b/source/css/_partial/header.styl
@@ -26,10 +26,11 @@
     width: $logo-width
     height: $logo-height
     border-radius: 5px
-    filter: grayscale(100%)
     background-size: $logo-width $logo-height
     background-repeat: no-repeat
-    -webkit-filter: grayscale(100%)
+    if $logo-grayout
+      filter: grayscale(100%)
+      -webkit-filter: grayscale(100%)
 
   #nav
     color: $color-accent-1
@@ -68,10 +69,11 @@
         a
           margin-right: 0
 
-#header:hover
-  #logo
-    filter: none
-    -webkit-filter: none
+if $logo-grayout
+  #header:hover
+    #logo
+      filter: none
+      -webkit-filter: none
 
 @media screen and (max-width: 480px)
   #header #title

--- a/source/css/_variables.styl
+++ b/source/css/_variables.styl
@@ -8,5 +8,6 @@ $page-width = 0rem + (hexo-config("page_width") || 39)
 // Logo
 $logo-width = 0px + (hexo-config("logo.width") || 0)
 $logo-height = 0px + (hexo-config("logo.height") || 0)
+$logo-grayout = hexo-config("logo-grayout")
 // Colors
 $colors = hexo-config("colorscheme") || "dark"


### PR DESCRIPTION
Hey there @probberechts 
Thanks for your great theme!

I tried to add an option to turn on/off the logo grayout effect (#210). Since it seems the current merge-config script is using shadow merge, I added a `logo-grayout` option out of `logo` configs. I'm wondering if it's ok.

I'll be appreciated if you can have a look at my pr.
Thank you!