### PR TITLE
Fix 2 keys of nav in zh-CN.yml

### DIFF
--- a/languages/zh-CN.yml
+++ b/languages/zh-CN.yml
@@ -3,8 +3,8 @@ nav:
   about: 关于
   articles: 归档
   projects: 项目
-  tag: 标签
-  category: 分类
+  tags: 标签
+  categories: 分类
   search: 搜索
 
 footer:


### PR DESCRIPTION
Hello!Probberechats.Thanks for your theme.
"tags"&"categories" are used in readme.md.It seems like we should modify them in /languages, so that they can work correctly.