### PR TITLE
Fix 'no results found' problem in search

### DIFF
--- a/layout/_partial/scripts.ejs
+++ b/layout/_partial/scripts.ejs
@@ -50,10 +50,12 @@
     });
 
     var observer = new MutationObserver(function(mutationsList, observer) {
-      if (mutationsList[0].addedNodes) {
-        $(".search-no-result").show(200);
-      } else {
-        $(".search-no-result").hide();
+      if (mutationsList.length == 1) {
+        if (mutationsList[0].addedNodes.length) {
+          $(".search-no-result").hide();
+        } else if (mutationsList[0].removedNodes.length) {
+          $(".search-no-result").show(200);
+        }
       }
     });
 

--- a/source/js/search.js
+++ b/source/js/search.js
@@ -139,15 +139,18 @@ var searchFunc = function(path, searchId, contentId) {
             resultList.push(searchResult);
           }
         });
-        resultList.sort(function(a, b) {
-            return b.rank - a.rank;
-        });
-        var result ="<ul class=\"search-result-list\">";
-        for (var i = 0; i < resultList.length; i++) {
-          result += resultList[i].str;
+		
+        if (resultList.length) {
+          resultList.sort(function(a, b) {
+              return b.rank - a.rank;
+          });
+          var result ="<ul class=\"search-result-list\">";
+          for (var i = 0; i < resultList.length; i++) {
+            result += resultList[i].str;
+          }
+          result += "</ul>";
+          $resultContent.innerHTML = result;
         }
-        result += "</ul>";
-        $resultContent.innerHTML = result;
       });
     }
   });


### PR DESCRIPTION
Currently `No results found.` is always shown even if search results not empty. 

# Before
https://probberechts.github.io/hexo-theme-cactus/cactus-white/public/search/.
![image](https://user-images.githubusercontent.com/36265606/73344173-db5fe080-42bc-11ea-9349-d0233aaf9724.png)

#  After
https://blog.yusanshi.com/search/
![image](https://user-images.githubusercontent.com/36265606/73344305-1bbf5e80-42bd-11ea-8c52-e6dd6b6f4683.png)
