### PR TITLE
Change favicon size & nav keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,10 @@ Setup the navigation menu in the `_config.yml`:
 
 ```yml
 nav:
-  Home: /
-  About: /about/
-  Writing: /archives/
-  Projects: http://github.com/probberechts
+  home: /
+  about: /about/
+  articles: /archives/
+  projects: http://github.com/probberechts
   LINK_NAME: URL
 ```
 
@@ -306,8 +306,8 @@ Finally, don't forget to create a link to these pages, for example in the naviga
 
 ```yml
 nav:
-  tags: /tags/
-  categories: /categories/
+  tag: /tags/
+  category: /categories/
 ```
 
 

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -15,7 +15,7 @@
     <% if (theme.favicon) { %>
         <% if (theme.favicon.desktop) { %>
           <% if (theme.gravatar && theme.gravatar.email && theme.favicon.desktop.gravatar) { %>
-              <link rel="shortcut icon" href="<%= gravatar(theme.gravatar.email, 16) %>">
+              <link rel="shortcut icon" href="<%= gravatar(theme.gravatar.email, 48) %>">
           <% } else { %>
               <link rel="shortcut icon" href="<%= url_for(theme.favicon.desktop.url) %>">
           <% } %>


### PR DESCRIPTION
1. Change desktop favicon size to 48, former 16x16 size looks outdated on a high-resolution screen.
2. Use corresponding nav keywords under languages/.