### PR TITLE
rss icon added for social media links

### DIFF
--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -11,8 +11,12 @@
         <% if (link == 'mail') { %>
           <a class="icon" target="_blank" rel="noopener" href="<%- theme.social_links[link] %>">
             <i class="fas fa-envelope"></i><!--
-      ---></a><!--
-      ---><% } else { %>
+      ---></a>
+        <% } else if (link == 'rss') { %>
+          <a class="icon" target="_blank" rel="noopener" href="<%- theme.social_links[link] %>">
+            <i class="fas fa-rss"></i>
+          </a>
+        <% } else { %>
           <a class="icon" target="_blank" rel="noopener" href="<%- url_for(theme.social_links[link]) %>">
             <i class="fab fa-<%= link %>"></i><!--
       ---></a><!--


### PR DESCRIPTION
Hey thanks for a awesome theme. I realized that fa brand icons doesn't include rss feed. For rss in social media links, I just added manually (like mail ==> envolope). 