### PR TITLE
Support for using hash on Gravatar options directly #243

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -156,7 +156,9 @@ umami_analytics:
   id: e77e68be-f6e4-4br3-9365-2b76b57cd571
   host: https://analytics.domain.com
 
-# Fill in you Gravatar user id / email if you want to use your gravatar as the
+# Fill in you Gravatar email or hash if you want to use your gravatar as the
 # logo and/or favicons of you website.
+# To generate hash: `$ echo -n "name@email.com" | md5`.
 gravatar:
   email: name@email.com
+  hash: d41d8cd98f00b204e9800998ecf8427e

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -13,27 +13,39 @@
     }) %>
     <%- meta(page) %>
     <% if (theme.favicon) { %>
-        <% if (theme.favicon.desktop) { %>
-          <% if (theme.gravatar && theme.gravatar.email && theme.favicon.desktop.gravatar) { %>
-              <link rel="shortcut icon" href="<%= gravatar(theme.gravatar.email, 48) %>">
+      <% if (theme.favicon.desktop) { %>
+        <% if (theme.gravatar && (theme.gravatar.email || theme.gravatar.hash) && theme.favicon.desktop.gravatar) { %>
+          <% if (theme.gravatar.email) { %>
+            <link rel="shortcut icon" href="<%= gravatar(theme.gravatar.email, 48) %>">
           <% } else { %>
-              <link rel="shortcut icon" href="<%= url_for(theme.favicon.desktop.url) %>">
+            <link rel="shortcut icon" href="https://www.gravatar.com/avatar/<%= theme.gravatar.hash %>?s=48">
           <% } %>
+        <% } else { %>
+          <link rel="shortcut icon" href="<%= url_for(theme.favicon.desktop.url) %>">
         <% } %>
-        <% if (theme.favicon.android) { %>
-          <% if (theme.gravatar && theme.gravatar.email && theme.favicon.android.gravatar) { %>
+      <% } %>
+      <% if (theme.favicon.android) { %>
+        <% if (theme.gravatar && (theme.gravatar.email || theme.gravatar.hash) && theme.favicon.android.gravatar) { %>
+          <% if (theme.gravatar.email) { %>
             <link rel="icon" type="image/png" href="<%= gravatar(theme.gravatar.email, 192) %>" sizes="192x192">
           <% } else { %>
-            <link rel="icon" type="image/png" href="<%= url_for(theme.favicon.android.url) %>" sizes="192x192">
+            <link rel="icon" type="image/png" href="https://www.gravatar.com/avatar/<%= theme.gravatar.hash %>?s=192">
           <% } %>
+        <% } else { %>
+          <link rel="icon" type="image/png" href="<%= url_for(theme.favicon.android.url) %>" sizes="192x192">
         <% } %>
-        <% if (theme.favicon.apple) { %>
-          <% if (theme.gravatar && theme.gravatar.email && theme.favicon.apple.gravatar) { %>
+      <% } %>
+      <% if (theme.favicon.apple) { %>
+        <% if (theme.gravatar && (theme.gravatar.email || theme.gravatar.hash) && theme.favicon.apple.gravatar) { %>
+          <% if (theme.gravatar.email) { %>
             <link rel="apple-touch-icon" sizes="180x180" href="<%= gravatar(theme.gravatar.email, 180) %>">
           <% } else { %>
-            <link rel="apple-touch-icon" sizes="180x180" href="<%= url_for(theme.favicon.apple.url) %>">
+            <link rel="apple-touch-icon" size="180x180" href="https://www.gravatar.com/avatar/<%= theme.gravatar.hash %>?s=180">
           <% } %>
+        <% } else { %>
+          <link rel="apple-touch-icon" sizes="180x180" href="<%= url_for(theme.favicon.apple.url) %>">
         <% } %>
+      <% } %>
     <% } %>
     <!-- title -->
     <title><%= page_title() %></title>

--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -1,8 +1,12 @@
 <header id="header">
   <a href="<%- url_for("/") %>">
   <% if (theme.logo && theme.logo.enabled) { %>
-    <% if (theme.gravatar && theme.gravatar.email && theme.logo.gravatar) { %>
-      <div id="logo" style="background-image: url(<%- gravatar(theme.gravatar.email) %>);"></div>
+    <% if (theme.gravatar && (theme.gravatar.email || theme.gravatar.hash) && theme.logo.gravatar) { %>
+      <% if (theme.gravatar.email) { %>
+        <div id="logo" style="background-image: url(<%- gravatar(theme.gravatar.email) %>);"></div>
+      <% } else { %>
+        <div id="logo" style="background-image: url(https://www.gravatar.com/avatar/<%= theme.gravatar.hash %>);"></div>
+      <% } %>
     <% } else { %>
       <div id="logo" style="background-image: url(<%- url_for(theme.logo.url) %>);"></div>
     <% } %>


### PR DESCRIPTION
#243 

Add `hash` option to `gravatar`.

Note that `gravatar.email` will come before `gravatar.hash`.