### PR TITLE
Fix a broken link for writing section

### DIFF
--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -32,7 +32,7 @@
 </section>
 
 <section id="writing">
-  <span class="h1"><a href="<%- url_for("archives") %>"><%= __('index.articles') %></a></span>
+  <span class="h1"><a href="<%- url_for(theme.nav.articles) %>"><%= __('index.articles') %></a></span>
   <% if (theme.tags_overview && site.tags.length) { %>
   <span class="h2"><%= __('index.topics') %></span>
   <span class="widget tagcloud">


### PR DESCRIPTION
Fixed a broken link for a writing page in Home.

---

Example:

Setup the navigation menu in the `_config.yml` as follows:

```yaml
nav:
  home: /
  articles: /posts/
```

Then,

- Actual: The link for the writing page in Home goes to `/archives/` (so, the link is broken).
- Expected: The link goes to `/posts/`.