### PR TITLE
Allow syntax highlighting style background to flow through, rather than be overridden by theme-defined background.

### DIFF
--- a/source/css/style.styl
+++ b/source/css/style.styl
@@ -153,7 +153,7 @@ code
   margin: 1rem 0
   padding: 10px 15px
   border-radius: 4px
-  background: $color-background-code
+  // background: $color-background-code
   font-family: $font-family-mono
   // color: $color-accent-3
   -webkit-border-radius: 4px


### PR DESCRIPTION
With apologies in advance, I have just begun to play with hexo and themes and really anything having to do with modern javascript frontends. So this might be really dumb. (Sorry also for the duplicate pull request!)

I kept messing around, trying to get syntax highlighting to work well with colorscheme: white, but the background color did not change with the syntax highlighting scheme as I would have wanted. This one-line hack did the trick. I'm not sure it was a great or the best way to do the trick, though.