### PR TITLE
feature: add mathJax support for latex

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,7 @@ projects_url: http://github.com/probberechts
 
 # Set the page direction to RTL or LTR. default is LTR. (if you set it 'rtl', the 'vazir' font will be loaded.)
 direction: ltr
+language: zh-CN
 # Configure the navigation menu.
 # A pair 'Key: url' will result in a link to 'url' with the name 'Key' in the
 # navigation menu. Optionally, you can add translations for the 'Key' in
@@ -137,9 +138,9 @@ open_graph:
 # Plugins
 ##############################################################################
 
-# Open MathJax support for Latex
+# Enable MathJax support for Latex
 
-MathJax: true
+mathjax: true
 
 # Fill in your Disqus Comments Shortname to enable Disqus comments.
 disqus:

--- a/_config.yml
+++ b/_config.yml
@@ -138,7 +138,6 @@ open_graph:
 ##############################################################################
 
 # Enable MathJax support for Latex
-
 mathjax: true
 
 # Fill in your Disqus Comments Shortname to enable Disqus comments.

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,6 @@ projects_url: http://github.com/probberechts
 
 # Set the page direction to RTL or LTR. default is LTR. (if you set it 'rtl', the 'vazir' font will be loaded.)
 direction: ltr
-language: zh-CN
 # Configure the navigation menu.
 # A pair 'Key: url' will result in a link to 'url' with the name 'Key' in the
 # navigation menu. Optionally, you can add translations for the 'Key' in

--- a/_config.yml
+++ b/_config.yml
@@ -138,7 +138,7 @@ open_graph:
 ##############################################################################
 
 # Enable MathJax support for Latex
-mathjax: true
+mathjax: false
 
 # Fill in your Disqus Comments Shortname to enable Disqus comments.
 disqus:

--- a/_config.yml
+++ b/_config.yml
@@ -138,8 +138,9 @@ open_graph:
 ##############################################################################
 
 # Enable MathJax support for Latex
-mathjax: false
-
+mathjax:
+  enabled: false
+  
 # Fill in your Disqus Comments Shortname to enable Disqus comments.
 disqus:
   enabled: false

--- a/_config.yml
+++ b/_config.yml
@@ -137,6 +137,10 @@ open_graph:
 # Plugins
 ##############################################################################
 
+# Open MathJax support for Latex
+
+MathJax: true
+
 # Fill in your Disqus Comments Shortname to enable Disqus comments.
 disqus:
   enabled: false

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -63,7 +63,7 @@
       <link rel="alternate" href="<%= url_for(theme.rss) %>" title="<%= config.title %>" type="application/atom+xml" />
     <% } %>
 	<!-- mathjax -->
-	<% if (theme.mathjax) {%>
+	<% if (theme.mathjax.enabled) {%>
 		<script type="text/x-mathjax-config">
 		  MathJax.Hub.Config({
 			tex2jax: {

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -62,4 +62,15 @@
     <% if (theme.rss) { %>
       <link rel="alternate" href="<%= url_for(theme.rss) %>" title="<%= config.title %>" type="application/atom+xml" />
     <% } %>
+	<% if (theme.MathJax) %>
+		<script type="text/x-mathjax-config">
+		  MathJax.Hub.Config({
+			tex2jax: {
+			  skipTags: ['script', 'noscript', 'style', 'textarea', 'pre'],
+			  inlineMath: [['$','$']]
+			}
+		  });
+		</script>
+		<script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-MML-AM_CHTML' async></script>
+	<% } %>
 </head>

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -62,7 +62,8 @@
     <% if (theme.rss) { %>
       <link rel="alternate" href="<%= url_for(theme.rss) %>" title="<%= config.title %>" type="application/atom+xml" />
     <% } %>
-	<% if (theme.MathJax) %>
+	<!-- mathjax -->
+	<% if (theme.mathjax) {%>
 		<script type="text/x-mathjax-config">
 		  MathJax.Hub.Config({
 			tex2jax: {


### PR DESCRIPTION
Added support for latex to display complex equations.
btw: Because the use of plugins may lead to too many theme changes, online loading plug-ins are used here. Users can close in _config.xml as needed.

![config](https://pic.tyzhang.top/images/2021/04/06/image.png)

![preview](https://camo.githubusercontent.com/574427c87e3f6219f8bd51790398a6890bccf89e2e748e8974074e702bae2666/68747470733a2f2f7069632e74797a68616e672e746f702f696d616765732f323032312f30332f31352f696d6167652e706e67)