### PR TITLE
Fix hidden menu bug

### DIFF
--- a/source/css/_partial/post/actions_desktop.styl
+++ b/source/css/_partial/post/actions_desktop.styl
@@ -64,7 +64,7 @@
     color: $color-accent-1
 
   #menu
-    visibility: hidden
+    display: none
     margin-right: 2rem
 
   #nav

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -33,7 +33,7 @@ $(document).ready(function() {
      * Display the menu on hi-res laptops and desktops.
      */
     if ($(document).width() >= 1440) {
-      menu.css("visibility", "visible");
+      menu.show();
       menuIcon.addClass("active");
     }
 
@@ -41,11 +41,11 @@ $(document).ready(function() {
      * Display the menu if the menu icon is clicked.
      */
     menuIcon.click(function() {
-      if (menu.css("visibility") === "hidden") {
-        menu.css("visibility", "visible");
+      if (menu.is(":hidden")) {
+        menu.show();
         menuIcon.addClass("active");
       } else {
-        menu.css("visibility", "hidden");
+        menu.hide();
         menuIcon.removeClass("active");
       }
       return false;


### PR DESCRIPTION
A minor bug related to the top menu.
Because the `#menu` uses `visibility: hidden` instead of `display: none`, it will always occupy the space on top of the main body. Then the width of it is large enough (due to long `#nav`) to block interactive elements under it. In the following case, copy button of the code block is not clickable.
![image](https://user-images.githubusercontent.com/58619636/115272272-ca74e680-a170-11eb-8216-ad073493b3d6.png)
![image](https://user-images.githubusercontent.com/58619636/115272910-7fa79e80-a171-11eb-9b38-2d42117d06a0.png)
p.s. In normal case this won't matter because `#nav` will be set to `display: none` when scrolling to post content. I found this issue when I was doing a refresh.