### PR TITLE
Customize scrollbar style

### DIFF
--- a/source/css/_colors/classic.styl
+++ b/source/css/_colors/classic.styl
@@ -3,6 +3,7 @@ $color-footer-mobile-1 = darken($color-background, 2%)
 $color-footer-mobile-2 = darken($color-background, 10%)
 $color-background-code = darken($color-background, 2%)
 $color-border = #666
+$color-scrollbar = #AAA
 $color-meta = #666
 $color-meta-code = lighten($color-meta, 10%)
 $color-link = rgba(86, 124, 119, .4)

--- a/source/css/_colors/dark.styl
+++ b/source/css/_colors/dark.styl
@@ -3,6 +3,7 @@ $color-footer-mobile-1 = lighten($color-background, 2%)
 $color-footer-mobile-2 = lighten($color-background, 10%)
 $color-background-code = lighten($color-background, 2%)
 $color-border = #908d8d
+$color-scrollbar = #999
 $color-meta = #908d8d
 $color-meta-code = #908d8d
 $color-link = rgba(212, 128, 170, 1)

--- a/source/css/_colors/light.styl
+++ b/source/css/_colors/light.styl
@@ -4,6 +4,7 @@ $color-footer-mobile-1 = darken($color-background, 2%)
 $color-footer-mobile-2 = darken($color-background, 10%)
 $color-background-code = darken($color-background, 2%)
 $color-border = #666
+$color-scrollbar = #999
 $color-meta = #666
 $color-meta-code = lighten($color-meta, 10%)
 $color-link = rgba(43, 188, 138, 1)

--- a/source/css/_colors/white.styl
+++ b/source/css/_colors/white.styl
@@ -4,6 +4,7 @@ $color-footer-mobile-1 = darken($color-background, 2%)
 $color-footer-mobile-2 = darken($color-background, 10%)
 $color-background-code = darken($color-background, 2%)
 $color-border = #666
+$color-scrollbar = #AAA
 $color-meta = #666
 $color-meta-code = lighten($color-meta, 10%)
 $color-link = rgba(212, 128, 170, 1)

--- a/source/css/style.styl
+++ b/source/css/style.styl
@@ -10,6 +10,29 @@ global-reset()
 *, *:before, *:after
   box-sizing: border-box
 
+/* Scroll bar */
+/* For Firefox */
+*
+  scrollbar-color: $color-scrollbar transparent
+
+/* For Chrome, Edge, and Safari */
+*::-webkit-scrollbar
+  width: 8px
+  height: 6px
+
+*::-webkit-scrollbar-track
+  background: transparent
+
+*::-webkit-scrollbar-thumb
+  background-color: $color-scrollbar
+  border-radius: 6px
+
+*::-webkit-scrollbar-thumb:hover
+  background-color: darken($color-scrollbar, 20%)
+
+*::-webkit-scrollbar-thumb:active
+  background-color: darken($color-scrollbar, 30%)
+
 html
   margin: 0
   padding: 0


### PR DESCRIPTION
Use [`scrollbar`](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Scrollbars) for Firefox and [`::-webkit-scrollbar`](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-scrollbar) for other browsers. Neither is stable and MDN suggests not using them in production; but since no standard solution exists at all let's just use them for now :P

All scrollbars including the vertical one for the whole page and those for code blocks are affected. Below are the effects:

- Dark

    ![image](https://user-images.githubusercontent.com/58619636/159139997-e1ec069b-0c40-4930-a890-3c912832b468.png)

- Light
    
    ![image](https://user-images.githubusercontent.com/58619636/159139862-48d0f47e-5209-4829-9074-c63bab32fded.png)

- Classic

    ![image](https://user-images.githubusercontent.com/58619636/159139897-c124edab-93cd-4491-b5c7-bcada6e69e26.png)

- White

    ![image](https://user-images.githubusercontent.com/58619636/159139943-df675c16-53c5-41ce-8d15-e822fcc974c2.png)

Tested only on Firefox and Chromium. Should have similar effects on most popular browsers according to MDN's compatibility table.

This should close #273.