### PR TITLE
Improve readme description

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A responsive, clean and simple [Hexo](http://hexo.io) theme for a personal websi
 
 - [General](#general)
 - [Features](#features)
+- [Prerequisites](#prerequisites)
 - [Install](#install)
 - [Configuration](#configuration)
 - [License](#license)

--- a/README.md
+++ b/README.md
@@ -38,22 +38,34 @@ A responsive, clean and simple [Hexo](http://hexo.io) theme for a personal websi
 In order to use this theme you must have installed [hexo](https://hexo.io/docs/).
 
 ## Install
-1. In the `root` directory:
+1. Create the `root` directory for the blog by initializing it with hexo:
 
-    ```git
+    ```sh
+    $ hexo init my-blog
+    ```
+
+2. Navigate into the new directory:
+
+    ```sh
+    $ cd my-blog
+    ```
+
+3. In the `root` directory:
+
+    ```sh
     $ git clone https://github.com/probberechts/hexo-theme-cactus.git themes/cactus
     ```
 
-2. Change the `theme` property in the `_config.yml` file.
+4. Change the `theme` property in the `_config.yml` file.
 
     ```yml
     # theme: landscape
     theme: cactus
     ```
-    See below for more information on how to customize this theme.
-    
-3. Create pages and articles with the `hexo new [layout] <title>` command.
-    For example, to create an "about me" page, run:
+   See below for more information on how to customize this theme.
+
+5. Create pages and articles with the `hexo new [layout] <title>` command.
+   For example, to create an "about me" page, run:
     ```sh
     $ hexo new page about
     ```
@@ -62,12 +74,11 @@ In order to use this theme you must have installed [hexo](https://hexo.io/docs/)
     ```sh
     $ hexo new post "hello world"
     ```
-    and add some interesting content in `source/_posts/hello-world.md`.
-    
-4. Run: `hexo generate` and `hexo server`
+   and add some interesting content in `source/_posts/hello-world.md`.
 
-5. [Publish your blog](https://hexo.io/docs/one-command-deployment.html)!
+6. Run: `hexo generate` and `hexo server`
 
+7. [Publish your blog](https://hexo.io/docs/one-command-deployment.html)!
 
 ## Configuration
 You can (and should) modify a couple of settings. An overview of all settings

--- a/README.md
+++ b/README.md
@@ -36,29 +36,29 @@ A responsive, clean and simple [Hexo](http://hexo.io) theme for a personal websi
 
 ## Prerequisites
 
-In order to use this theme you must have installed [hexo](https://hexo.io/docs/).
+1. In order to use this theme you must have installed [hexo](https://hexo.io/docs/).
 
-## Install
-
-1. Create the `root` directory for the blog by initializing it with hexo:
+2. Create the `root` directory for the blog by initializing it with hexo:
 
     ```sh
     $ hexo init my-blog
     ```
 
-2. Navigate into the new directory:
+3. Navigate into the new directory:
 
     ```sh
     $ cd my-blog
     ```
 
-3. In the `root` directory:
+## Install
+
+1. In the `root` directory:
 
     ```sh
     $ git clone https://github.com/probberechts/hexo-theme-cactus.git themes/cactus
     ```
 
-4. Change the `theme` property in the `_config.yml` file.
+2. Change the `theme` property in the `_config.yml` file.
 
     ```yml
     # theme: landscape
@@ -67,7 +67,7 @@ In order to use this theme you must have installed [hexo](https://hexo.io/docs/)
    
    See below for more information on how to customize this theme.
 
-5. Create pages and articles with the `hexo new [layout] <title>` command.
+3. Create pages and articles with the `hexo new [layout] <title>` command.
    For example, to create an "about me" page, run:
    
     ```sh
@@ -83,9 +83,9 @@ In order to use this theme you must have installed [hexo](https://hexo.io/docs/)
    
    and add some interesting content in `source/_posts/hello-world.md`.
 
-6. Run: `hexo generate` and `hexo server`
+4. Run: `hexo generate` and `hexo server`
 
-7. [Publish your blog](https://hexo.io/docs/one-command-deployment.html)!
+5. [Publish your blog](https://hexo.io/docs/one-command-deployment.html)!
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ A responsive, clean and simple [Hexo](http://hexo.io) theme for a personal websi
 
 ![screenshot](https://user-images.githubusercontent.com/2175271/137625287-24a4ac77-fbc9-4c99-a4cd-90455d93d13c.png)
 
-
 ## Summary
 
 - [General](#general)
@@ -36,9 +35,11 @@ A responsive, clean and simple [Hexo](http://hexo.io) theme for a personal websi
 - Simplicity
 
 ## Prerequisites
+
 In order to use this theme you must have installed [hexo](https://hexo.io/docs/).
 
 ## Install
+
 1. Create the `root` directory for the blog by initializing it with hexo:
 
     ```sh
@@ -63,18 +64,23 @@ In order to use this theme you must have installed [hexo](https://hexo.io/docs/)
     # theme: landscape
     theme: cactus
     ```
+   
    See below for more information on how to customize this theme.
 
 5. Create pages and articles with the `hexo new [layout] <title>` command.
    For example, to create an "about me" page, run:
+   
     ```sh
     $ hexo new page about
     ```
+   
    This will create a new file in `source/about/index.md`
    Similarly, you can create a new article with
+   
     ```sh
     $ hexo new post "hello world"
     ```
+   
    and add some interesting content in `source/_posts/hello-world.md`.
 
 6. Run: `hexo generate` and `hexo server`
@@ -82,6 +88,7 @@ In order to use this theme you must have installed [hexo](https://hexo.io/docs/)
 7. [Publish your blog](https://hexo.io/docs/one-command-deployment.html)!
 
 ## Configuration
+
 You can (and should) modify a couple of settings. An overview of all settings
 can be found in  [_config.yml](_config.yml). The most important ones are
 discussed below.
@@ -98,14 +105,12 @@ theme_config:
   colorscheme: white
 ```
 
-
 ```yml
 # themes/cactus/_config.yml
 colorscheme: dark
 ```
 
 This will override the default black colorscheme in `themes/cactus/_config.yml`.
-
 
 ### Color scheme
 
@@ -119,7 +124,6 @@ colorscheme: light
 Alternatively, you can easily create your own color scheme by creating a new
 file in `source/css/_colors`.
 
-
 ### Navigation
 
 Set up the navigation menu in the `_config.yml`:
@@ -132,7 +136,6 @@ nav:
   projects: http://github.com/probberechts
   LINK_NAME: URL
 ```
-
 
 ### Blog posts list on home page
 
@@ -153,7 +156,6 @@ You have two options for the list of blog posts on the home page:
       show_all_posts: true
     ```
 
-
 ### Projects list
 
 Create a projects file `source/_data/projects.json` to show a list of your projects on the index page.
@@ -172,7 +174,6 @@ Create a projects file `source/_data/projects.json` to show a list of your proje
     }
 ]
 ```
-
 
 ### Social media links
 
@@ -230,6 +231,7 @@ Otherwise, you can follow the steps below (E.g., to add a Japanese (ja) translat
 **Note: Cactus does not support multi-language sites.**
 
 ### RTL support
+
 This theme support RTL languages for Persian and Arabic language.
 If you would like to use RTL layout, change `direction` attribute in `_config.yml` to `rtl`.
 Note that this also will change the font to [Vazir](https://github.com/rastikerdar/vazir-font), which is a Persian font.
@@ -245,7 +247,6 @@ Set the `rss` field in the `_config.yml` to one of the following values:
 1. `rss: false` will totally disable rss (default).
 2. `rss: atom.xml` sets a specific feed link.
 3. `rss:`leave empty to use the [hexo-generator-feed](https://github.com/hexojs/hexo-generator-feed) plugin.
-
 
 ### Analytics
 
@@ -343,6 +344,7 @@ highlight: COLORSCHEME_NAME
 ```
 
 ### Tags and categories
+
 Tags and categories can be included in the front-matter of your posts. For example:
 
 ```markdown
@@ -383,7 +385,6 @@ nav:
   category: /categories/
 ```
 
-
 ### Local search
 
 First, install the [hexo-generate-search](https://www.npmjs.com/package/hexo-generator-search)
@@ -398,6 +399,7 @@ Next, create a page to display the search engine:
 ```sh
 $ hexo new page search
 ```
+
 and put `type: search` in the front-matter.
 
 ```markdown
@@ -414,4 +416,5 @@ nav:
 ```
 
 ## License
+
 MIT

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ In order to use this theme you must have installed [hexo](https://hexo.io/docs/)
     $ git clone https://github.com/probberechts/hexo-theme-cactus.git themes/cactus
     ```
 
-2. Change the `theme` property in the `config.yml` file.
+2. Change the `theme` property in the `_config.yml` file.
 
     ```yml
     # theme: landscape

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ file in `source/css/_colors`.
 
 ### Navigation
 
-Setup the navigation menu in the `_config.yml`:
+Set up the navigation menu in the `_config.yml`:
 
 ```yml
 nav:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ A responsive, clean and simple [Hexo](http://hexo.io) theme for a personal websi
 - Font Awesome icons
 - Simplicity
 
+## Prerequisites
+In order to use this theme you must have installed [hexo](https://hexo.io/docs/).
+
 ## Install
 1. In the `root` directory:
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ In order to use this theme you must have installed [hexo](https://hexo.io/docs/)
     ```sh
     $ hexo new page about
     ```
-    This will create a new file in `source/about/index.md`
-    Similary, you can create a new article with
+   This will create a new file in `source/about/index.md`
+   Similarly, you can create a new article with
     ```sh
     $ hexo new post "hello world"
     ```


### PR DESCRIPTION
I am new to hexo, so I had problems setting up the template for the first time.
After reading the description of another hexo template I realized, the description of the installation process omitted two steps, which i added with https://github.com/probberechts/hexo-theme-cactus/commit/6d2dc29671123f22dac3a9569306da6e53aca7c0

I also fixed some minor typos and unified the formatting.