### PR TITLE
Fix wrong utterances example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ First, follow the instructions on the [oficial website](https://utteranc.es/) to
 Next, update the `_config.yml` file:
 
 ```yml
-utteranc:
+utterances:
   enabled: true
   repo: owner/githubrepo
   issue_term: pathname


### PR DESCRIPTION
- The example shown in README for utterances config uses the wrong key ( `utteranc` instead of `utterances`)