### PR TITLE
Fix upscrolling bug in chrome. See issue #313

### DIFF
--- a/source/js/main.js
+++ b/source/js/main.js
@@ -59,7 +59,7 @@ $(document).ready(function() {
         var topDistance = menu.offset().top;
 
         // hide only the navigation links on desktop
-        if (!nav.is(":visible") && topDistance < 50) {
+        if (!nav.is(":visible") && topDistance < 100) {
           nav.show();
         } else if (nav.is(":visible") && topDistance > 100) {
           nav.hide();


### PR DESCRIPTION
Fix: upscrolling bug in chrome. See #313 
Possible reason:  May be related to how DOM elements are accessed by different browsers (in this case position value relative to the document). [See](https://stackoverflow.com/questions/23216827/issue-with-offset-top-on-chrome) for details.