### PR TITLE
Fixed NaN error in archive.ejs

### DIFF
--- a/layout/archive.ejs
+++ b/layout/archive.ejs
@@ -4,7 +4,7 @@
     <% var change = false %>
     <% var field_sort = theme.archive.sort_updated ? 'updated' : 'date' %>
     <% page.posts.sort(field_sort, 'desc').each(function(post) { %>
-      <% var itemYear = date(post[field_sort], 'YYYY') - 0 %>
+      <% var itemYear = date(post[field_sort], 'YYYY') %>
       <% change = year !== itemYear %>
       <% year = change ? itemYear : year %>
       <% if (change) { %>

--- a/source/css/style.styl
+++ b/source/css/style.styl
@@ -232,3 +232,6 @@ code
 
   .line
     height: 22px
+
+#header-post #actions
+  direction: ltr !important


### PR DESCRIPTION
Fixed NaN error message in archive.ejs. Particularly shown in archive page.

**Image before fixing the bug**

![Before](https://user-images.githubusercontent.com/74807046/182161679-bd41e1c7-b11f-455e-b7d2-870d40e4bdbd.png)

**Image after fixing the bug**

![After](https://user-images.githubusercontent.com/74807046/182161726-0ca75e55-e61f-4f0a-b244-80a2ff279b4d.png)

In addition, fixed span#actions element direction for RTL languages. The direction does not need to be changed, the current styling after making the theme's direction RTL by using RTL languages messes up the action element as shown in following pictures.

**Before fixing span#actions**

![Before](https://user-images.githubusercontent.com/74807046/182165238-9cbeee6a-0244-4bd9-bc31-8e9248a137d9.png)

**After fixing span#actions**

![After](https://user-images.githubusercontent.com/74807046/182165320-5303ecec-5ae8-4cfe-9474-59b25ab2f254.png)

The bug is successfully fixed and it has been tested for RTL languages(Persian language) as shown in the pictures above.