### PR TITLE
Add 404 Page Generating Support

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -65,6 +65,15 @@ copyright:
   start_year: 2016
   end_year:
 
+# Customize the 404 page
+# Options:
+#   - enabled: whether to enable the 404 page (404.html).
+error_404:
+  enabled: true
+  title: "404 Page Not Found"
+  description: "The page you are looking for might have been removed, had its name changed, or is temporarily unavailable."
+
+
 ##############################################################################
 # Look and Feel
 ##############################################################################

--- a/layout/404.ejs
+++ b/layout/404.ejs
@@ -1,0 +1,9 @@
+<article class="post" itemscope itemtype="http://schema.org/BlogPosting">
+    <%- partial('_partial/post/gallery') %>
+    <div class="content" itemprop="articleBody">
+        <% if (theme.error_404.enabled && theme.error_404.title && theme.error_404.description ) { %>
+            <h1><%= theme.error_404.title %></h1>
+            <p><%= theme.error_404.description %></p>
+        <% } %>
+    </div>
+</article>

--- a/scripts/errror_404.js
+++ b/scripts/errror_404.js
@@ -1,0 +1,12 @@
+/**
+* error 404 page Generator
+* @description generate the 404.html in root directory
+*/
+
+hexo.extend.generator.register('error_404', function (locals) {
+    return {
+        path: '404.html',
+        data: locals.posts,
+        layout: '404'
+    }
+})


### PR DESCRIPTION
As #290 mentioned, theme-cactus lacks support for generating a 404 page, which is not visitor-friendly.
I added a simple 404-page generating feature that only shows visitors a customized title and description text.