### PR TITLE
fix(google analytics): put the analytics in the <head>

### DIFF
--- a/layout/_partial/google_analytics.ejs
+++ b/layout/_partial/google_analytics.ejs
@@ -1,0 +1,10 @@
+<!-- Google Analytics -->
+<% if (theme.google_analytics.enabled && theme.google_analytics.id){ %>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=<%= theme.google_analytics.id %>"></script>
+  <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', '<%= theme.google_analytics.id %>');
+  </script>
+<% } %>

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -1,5 +1,4 @@
 <head>
-    <%- partial('./google_analytics.ejs') %>
     <!-- so meta -->
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -50,6 +49,8 @@
     <% } %>
     <!-- title -->
     <title><%= page_title() %></title>
+    <!-- async scripts -->
+    <%- partial('./google_analytics.ejs') %>
     <!-- styles -->
     <%- css('css/style') %>
     <!-- persian styles -->

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -1,4 +1,5 @@
 <head>
+    <%- partial('./google_analytics.ejs') %>
     <!-- so meta -->
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/layout/_partial/scripts.ejs
+++ b/layout/_partial/scripts.ejs
@@ -80,16 +80,6 @@
   });
   </script>
 <% } %>
-<!-- Google Analytics -->
-<% if (theme.google_analytics.enabled && theme.google_analytics.id){ %>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=<%= theme.google_analytics.id %>"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', '<%= theme.google_analytics.id %>');
-    </script>
-<% } %>
 <!-- Baidu Analytics -->
 <% if (theme.baidu_analytics.enabled && theme.baidu_analytics.id){ %>
   <script type="text/javascript">


### PR DESCRIPTION
Accroding to the [guide](https://developers.google.com/analytics/devguides/collection/gtagjs?hl=en#install_the_google_tag), the google analytics code should be put after the `<head>`, the current code puts this in the `<body>`, which is not correct, so this commits does two things to fix this:

+ add a new template file called `google_analytics.ejs` to move the logic from `scripts.ejs`.
+ add a new line in `head.ejs` to incorporate `google_analytics.ejs`.