### PR TITLE
Add support for `rel="me"` microformat for `social_links`

### DIFF
--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -17,7 +17,7 @@
             <i class="fas fa-rss"></i>
           </a>
         <% } else { %>
-          <a class="icon" target="_blank" rel="noopener" href="<%- url_for(theme.social_links[link]) %>" aria-label="<%- link %>">
+          <a class="icon" target="_blank" rel="noopener me" href="<%- url_for(theme.social_links[link]) %>" aria-label="<%- link %>">
             <i class="fab fa-<%= link %>"></i><!--
       ---></a><!--
     ---><% } %><!--


### PR DESCRIPTION
Hello 👋 

Here is a super simple change to add support for `rel="me"` micro-format. It's especially useful for Mastodon users as it allows [profile link verification](https://docs.joinmastodon.org/user/profile/#verification) on that platform. 

According to [micro-formats specification](https://microformats.org/wiki/rel-me), it can be used "_on any hyperlinks from one page about a person to other pages about that same person_", so I added it on every `social_links`.

Best ^^