### PR TITLE
Replace gulp-download with gulp-download-stream

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,6 @@
 var decompress = require('gulp-decompress');
 var del = require('del');
-var download = require("gulp-download");
+var download = require("gulp-download-stream");
 var fs = require('fs');
 var gulp = require('gulp');
 var path = require('path');

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "del": "*",
     "gulp": "^4.0.0",
     "gulp-decompress": "*",
-    "gulp-download": "*",
+    "gulp-download-stream": "*",
     "gulp-jshint": "*",
     "gulp-stylint": "*",
     "js-yaml": "*",


### PR DESCRIPTION
[gulp-download](https://www.npmjs.com/package/gulp-download) has not been updated since 9 years!
It contains [gulp-util](https://www.npmjs.com/package/gulp-util), which has been [deprecated](https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5).

I looked for alternatives and believe that [gulp-download-stream](https://www.npmjs.com/package/gulp-download-stream) is sufficient.
* The dependency is currently still maintained (last published 4 months ago)
* From the documented usage in the `README`-file the behaviour seems to be the same as the other dependency

`gulp-util` contains dependencies, which might contain security issues (I am no expert!)

Replacing this indeed removes a lot of lodash dependencies and `npm install` shows that the change removes one **critical** issue:
**Before**
`found 20 vulnerabilities (7 low, 3 moderate, 9 high, 1 critical)`
**After**
`found 19 vulnerabilities (7 low, 3 moderate, 9 high)`

