### PR TITLE
Better support for Microformats

### DIFF
--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -3,12 +3,16 @@
   <% if (theme.logo && theme.logo.enabled) { %>
     <% if (theme.gravatar && (theme.gravatar.email || theme.gravatar.hash) && theme.logo.gravatar) { %>
       <% if (theme.gravatar.email) { %>
-        <img id="logo" class="u-logo" src="<%- gravatar(theme.gravatar.email) %>" />
+        <img id="logo" alt class="u-logo" 
+          srcset="<%- gravatar(theme.gravatar.email) %>?s=<%= theme.logo.width %>, <%- gravatar(theme.gravatar.email) %>?s=<%= theme.logo.width*1.5 %> 1.5x, <%- gravatar(theme.gravatar.email) %>?s=<%= theme.logo.width*2 %> 2x"
+          src="<%- gravatar(theme.gravatar.email) %>" />
       <% } else { %>
-        <img id="logo" class="u-logo" src="https://www.gravatar.com/avatar/<%= theme.gravatar.hash %>" />
+        <img id="logo" alt class="u-logo" 
+          srcset="https://www.gravatar.com/avatar/<%= theme.gravatar.hash %>?s=<%= theme.logo.width %>, https://www.gravatar.com/avatar/<%= theme.gravatar.hash %>?s=<%= theme.logo.width*1.5 %> 1.5x, https://www.gravatar.com/avatar/<%= theme.gravatar.hash %>?s=<%= theme.logo.width*2 %> 2x"
+          src="https://www.gravatar.com/avatar/<%= theme.gravatar.hash %>" />
       <% } %>
     <% } else { %>
-      <img id="logo" class="u-logo" src="<%- url_for(theme.logo.url) %>" />
+      <img id="logo" alt class="u-logo" src="<%- url_for(theme.logo.url) %>" />
     <% } %>
   <% } %>
     <div id="title">

--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -1,4 +1,4 @@
-<header id="header" class="h-card">
+<header id="header">
   <a class="u-url" href="<%- url_for("/") %>">
   <% if (theme.logo && theme.logo.enabled) { %>
     <% if (theme.gravatar && (theme.gravatar.email || theme.gravatar.hash) && theme.logo.gravatar) { %>

--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -1,5 +1,5 @@
-<header id="header">
-  <a href="<%- url_for("/") %>">
+<header id="header" class="h-card">
+  <a class="u-url" href="<%- url_for("/") %>">
   <% if (theme.logo && theme.logo.enabled) { %>
     <% if (theme.gravatar && (theme.gravatar.email || theme.gravatar.hash) && theme.logo.gravatar) { %>
       <% if (theme.gravatar.email) { %>
@@ -12,7 +12,7 @@
     <% } %>
   <% } %>
     <div id="title">
-      <h1><%= config.title %></h1>
+      <h1 class="p-name"><%= config.title %></h1>
     </div>
   </a>
   <div id="nav">

--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -1,5 +1,5 @@
 <header id="header">
-  <a class="u-url" href="<%- url_for("/") %>">
+  <a class="u-url u-uid" href="<%- url_for("/") %>">
   <% if (theme.logo && theme.logo.enabled) { %>
     <% if (theme.gravatar && (theme.gravatar.email || theme.gravatar.hash) && theme.logo.gravatar) { %>
       <% if (theme.gravatar.email) { %>

--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -3,12 +3,12 @@
   <% if (theme.logo && theme.logo.enabled) { %>
     <% if (theme.gravatar && (theme.gravatar.email || theme.gravatar.hash) && theme.logo.gravatar) { %>
       <% if (theme.gravatar.email) { %>
-        <div id="logo" style="background-image: url(<%- gravatar(theme.gravatar.email) %>);"></div>
+        <img id="logo" class="u-logo" src="<%- gravatar(theme.gravatar.email) %>" />
       <% } else { %>
-        <div id="logo" style="background-image: url(https://www.gravatar.com/avatar/<%= theme.gravatar.hash %>);"></div>
+        <img id="logo" class="u-logo" src="https://www.gravatar.com/avatar/<%= theme.gravatar.hash %>" />
       <% } %>
     <% } else { %>
-      <div id="logo" style="background-image: url(<%- url_for(theme.logo.url) %>);"></div>
+      <img id="logo" class="u-logo" src="<%- url_for(theme.logo.url) %>" />
     <% } %>
   <% } %>
     <div id="title">

--- a/layout/_partial/post/date.ejs
+++ b/layout/_partial/post/date.ejs
@@ -1,15 +1,15 @@
 <% if (post.date) { %>
     <div class="<%= class_name %>">
       <% if (is_post()) { %>
-        <time datetime="<%= date_xml(post.date) %>" itemprop="datePublished"><%= date(post.date, config.date_format) %></time>
+        <time datetime="<%= date_xml(post.date) %>" class="dt-published" itemprop="datePublished"><%= date(post.date, config.date_format) %></time>
         <% if (theme.post.show_updated && post.date !== post.updated) { %>
-        (Updated: <time datetime="<%= date_xml(post.updated) %>" itemprop="dateModified"><%= date(post.updated, config.date_format) %></time>)
+        (Updated: <time datetime="<%= date_xml(post.updated) %>" class="dt-updated" itemprop="dateModified"><%= date(post.updated, config.date_format) %></time>)
         <% } %>
       <% } else { %>
         <% if (is_home() && theme.posts_overview.sort_updated || is_archive() && theme.archive.sort_updated ) { %>
-          <time datetime="<%= date_xml(post.updated) %>" itemprop="dateModified"><%= date(post.updated, config.date_format) %></time>
+          <time datetime="<%= date_xml(post.updated) %>" class="dt-updated" itemprop="dateModified"><%= date(post.updated, config.date_format) %></time>
         <% } else { %>
-          <time datetime="<%= date_xml(post.date) %>" itemprop="datePublished"><%= date(post.date, config.date_format) %></time>
+          <time datetime="<%= date_xml(post.date) %>" class="dt-published" itemprop="datePublished"><%= date(post.date, config.date_format) %></time>
         <% } %>
       <% } %>
     </div>

--- a/layout/_partial/post/tag.ejs
+++ b/layout/_partial/post/tag.ejs
@@ -1,6 +1,6 @@
 <% if (page.tags && page.tags.length) { %>
     <div class="article-tag">
         <i class="fas fa-tag"></i>
-        <%- list_tags(page.tags, { show_count: false, style: 'list', class: {a: 'p-category' }}) %>
+        <%- list_tags(page.tags, { show_count: false, style: 'link', class: {a: 'p-category' }}) %>
     </div>
 <% } %>

--- a/layout/_partial/post/tag.ejs
+++ b/layout/_partial/post/tag.ejs
@@ -1,6 +1,6 @@
 <% if (page.tags && page.tags.length) { %>
     <div class="article-tag">
         <i class="fas fa-tag"></i>
-        <%- list_tags(page.tags, { show_count: false, style: 'link' }) %>
+        <%- list_tags(page.tags, { show_count: false, style: 'list', class: {a: 'p-category' }}) %>
     </div>
 <% } %>

--- a/layout/_partial/post/title.ejs
+++ b/layout/_partial/post/title.ejs
@@ -7,7 +7,7 @@
         <a class="<%= class_name %>" href="<%- url_for(post.path) %>">Untitled</a>
     <% } %>
 <% } else { %>
-    <h1 class="<%= class_name %>" itemprop="name headline">
+    <h1 class="<%= class_name %> p-name" itemprop="name headline">
         <%= post.title %>
     </h1>
 <% } %>

--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -9,7 +9,7 @@
       <% var i = 0 %>
       <% for(var link in theme.social_links) { %>
         <% if (link == 'mail') { %>
-          <a class="icon" target="_blank" rel="noopener" href="<%- theme.social_links[link] %>" aria-label="<%- link %>">
+          <a class="icon u-email" target="_blank" rel="noopener" href="<%- theme.social_links[link] %>" aria-label="<%- link %>">
             <i class="fas fa-envelope"></i><!--
       ---></a>
         <% } else if (link == 'rss') { %>

--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -17,7 +17,7 @@
             <i class="fas fa-rss"></i>
           </a>
         <% } else { %>
-          <a class="icon" target="_blank" rel="noopener me" href="<%- url_for(theme.social_links[link]) %>" aria-label="<%- link %>">
+          <a class="icon u-url" target="_blank" rel="noopener me" href="<%- url_for(theme.social_links[link]) %>" aria-label="<%- link %>">
             <i class="fab fa-<%= link %>"></i><!--
       ---></a><!--
     ---><% } %><!--

--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -1,4 +1,4 @@
-<section id="about">
+<section id="about" class="p-note">
   <% if (config.description) { %>
     <%- markdown(config.description) %>
   <% } %>

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -5,7 +5,7 @@
     <% if (is_post()) { %>
       <%- partial('_partial/post/actions_desktop') %>
     <% } %>
-    <div class="content index py4">
+    <div class="content index py4 h-card">
         <% if (!is_post()) { %>
           <%- partial('_partial/header') %>
         <% } %>

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -5,7 +5,7 @@
     <% if (is_post()) { %>
       <%- partial('_partial/post/actions_desktop') %>
     <% } %>
-    <div class="content index py4 h-card">
+    <div class="content index py4 <%= is_home() ? 'h-card' : '' %>">
         <% if (!is_post()) { %>
           <%- partial('_partial/header') %>
         <% } %>

--- a/layout/post.ejs
+++ b/layout/post.ejs
@@ -1,9 +1,9 @@
-<article class="post" itemscope itemtype="http://schema.org/BlogPosting">
+<article class="post h-entry" itemscope itemtype="http://schema.org/BlogPosting">
   <header>
     <%- partial('_partial/post/title', { post: page, index: false, class_name: 'posttitle' }) %>
     <div class="meta">
-      <span class="author" itemprop="author" itemscope itemtype="http://schema.org/Person">
-        <span itemprop="name"><% if (page.author) { %><%- page.author %><% } else { %><%- config.author %><% } %></span>
+      <span class="author p-author h-card" itemprop="author" itemscope itemtype="http://schema.org/Person">
+        <span class="p-name" itemprop="name"><% if (page.author) { %><%- page.author %><% } else { %><%- config.author %><% } %></span>
       </span>
       <%- partial('_partial/post/date', { post: page, class_name: 'postdate' }) %>
       <%- partial('_partial/post/category') %>
@@ -11,7 +11,7 @@
     </div>
   </header>
   <%- partial('_partial/post/gallery') %>
-  <div class="content" itemprop="articleBody">
+  <div class="content e-content" itemprop="articleBody">
     <%- page.content %>
   </div>
 </article>

--- a/source/css/_partial/header.styl
+++ b/source/css/_partial/header.styl
@@ -98,10 +98,17 @@ if $logo-grayout
         top: 77px
         right: 1rem
         display: inline-block
+        text-align: center
 
     ul.responsive
       li
         display: block
+    
+    ul 
+      a[aria-label="Menu"]
+        display: inline-block
+        min-width: 48px
+        min-height: 48px
 
     li:not(:first-child)
       padding-top: 1rem


### PR DESCRIPTION
Hello 👋 

This PR intent to improve support for [microformat2](https://microformats.org/wiki/microformats2) in the markup. 
I mostly ran the validator available on [IndieWebify.Me](https://indiewebify.me/) (See _"Publishing on the IndieWeb Level 2 / 1. Mark up your content"_ section) and followed instructions to fix/improve support. 

Adds support for [`h-card`](https://microformats.org/wiki/h-card) on the home page, and [`h-entry`](http://microformats.org/wiki/h-entry) in the post layout. More details bellow.

I did it for my own usage, and I guess it might be useful to other people as well. 

Best ^^

### 1. Support for `h-card` on the home page 

`h-card` is used to identify the website owner. 
I added support for the following microformats:
 - `h-card` : Main container
 - `u-url` : website URL (or links to other URL representing the person or organisation)
 - `p-name` : organisation or person name
 - `u-email` : email address
 - `u-logo` : logo representing the person or organization
 - `p-note` : additional notes (used with `config.description`)

### 2. Support for `h-entry` in the post layout

`h-entry` is used to identify blog posts. 
I added support for the following microformats:
 - `h-entry` : Main container. 
 - `p-name` : post title
 - `u-url` : permalink URL
 - `e-content` : Content of the post
 - `dt-published` : date published
 - `dt-updated` : date updated
 - `p-author` : Post author
 - `p-category` for tags & categories

