### PR TITLE
social_links: Support multiple links per platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,12 +182,20 @@ Therefore, update the theme's `_config.yml`:
 
 ```yml
 social_links:
-  github: your-github-url
-  twitter: your-twitter-url
-  NAME: your-NAME-url
+  -
+    icon: github
+    link: your-github-url
+  -
+    icon: twitter
+    label: "@your-twitter-handle"
+    link: your-twitter-url
+  -
+    icon: NAME
+    label: LABEL
+    link: your-NAME-url
 ```
 
-where `NAME` is the name of a [Font Awesome icon](https://fontawesome.com/icons?d=gallery&s=brands).
+where `NAME` is the name of a [Font Awesome icon](https://fontawesome.com/icons?d=gallery&s=brands), and LABEL is an optional value used as a title attribute on the link (NAME value is used if LABEL is missing).
 
 ### Copyright years
 

--- a/_config.yml
+++ b/_config.yml
@@ -21,15 +21,32 @@ nav:
 
 
 # Links to your social media accounts.
-# The keys should correspond to Fontawesome icon names
+# The 'icon' keys should correspond to Fontawesome icon names
 # (see https://fontawesome.com/icons?d=gallery&s=brands);
 # only 'mail' is an exception.
+# You can optionally add a 'label' key to set the title attribute on the link. 
+# 'icon' value will be used as title when 'label' is missing.
 social_links:
-  github: http://github.com/probberechts/cactus-dark
-  twitter: /
-  facebook: /
-  linkedin: /
-  mail: mailto:name@email.com
+  -
+    icon: github
+    link: http://github.com/probberechts/cactus-dark
+  -
+    icon: twitter
+    link: /
+  -
+    icon: facebook
+    link: /
+  -
+    icon: mail
+    link: mailto:name@email.com
+  -
+    icon: mastodon
+    label: mastodon.social
+    link: https://mastodon.social/@alice
+  -
+    icon: mastodon
+    label: fosstodon.org
+    link: https://fosstodon.org/@alice
 
 # Customize the overview with displaying a tagcloud on the index page.
 # Options: https://hexo.io/docs/helpers.html#tagcloud

--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -5,20 +5,21 @@
   <% if (theme.social_links) { %>
     <p>
       <%= __('index.find_me_on') %>
-      <% var nb_links = Object.keys(theme.social_links).length %>
+      <% var nb_links = theme.social_links.length %>
       <% var i = 0 %>
-      <% for(var link in theme.social_links) { %>
-        <% if (link == 'mail') { %>
-          <a class="icon" target="_blank" rel="noopener" href="<%- theme.social_links[link] %>" aria-label="<%- link %>">
+      <% for(var {label, icon, link} of theme.social_links) { %>
+        <% var title = label || icon %>
+        <% if (icon == 'mail') { %>
+          <a class="icon" target="_blank" rel="noopener" href="<%- link %>" aria-label="<%- title %>" title="<%- title %>">
             <i class="fas fa-envelope"></i><!--
       ---></a>
-        <% } else if (link == 'rss') { %>
-          <a class="icon" target="_blank" rel="noopener" href="<%- theme.social_links[link] %>" aria-label="<%- link %>">
+        <% } else if (icon == 'rss') { %>
+          <a class="icon" target="_blank" rel="noopener" href="<%- link %>" aria-label="<%- title %>" title="<%- title %>">
             <i class="fas fa-rss"></i>
           </a>
         <% } else { %>
-          <a class="icon" target="_blank" rel="noopener me" href="<%- url_for(theme.social_links[link]) %>" aria-label="<%- link %>">
-            <i class="fab fa-<%= link %>"></i><!--
+          <a class="icon" target="_blank" rel="noopener me" href="<%- url_for(link) %>" aria-label="<%- title %>" title="<%- title %>">
+            <i class="fab fa-<%= icon %>"></i><!--
       ---></a><!--
     ---><% } %><!--
     ---><%= ( nb_links > 0 && i < nb_links-1 ?


### PR DESCRIPTION
Hello,

`social_links` currently only allows on single link per service/platform, as the `key` must correspond to Fontawesome icon name.

This change proposal adds support for multiple links per service/platform.
It allows users who have multiple accounts on a single service, which is quite frequent on Twitter or Mastodon for example, to list them all while using the correct Fontawesome icon. 
Optional custom `label` helps providing disambiguation between similar icon links, and also improves accessibility by adding a `title` attribute to the link.

For example:
``` yaml
social_links:
  -
    icon: mastodon
    label: "@alice@mastodon.social"
    link: https://mastodon.social/@alice
  -
    icon: mastodon
    label: "@alice@fosstodon.org"
    link: https://fosstodon.org/@alice
```
`_config.yml` becomes significantly more verbose, but also provides more flexibility for advanced users.

As an example, here is a screen-capture from [my own website](https://olivier.audard.net) 👇 
<img width="370" alt="image" src="https://user-images.githubusercontent.com/832355/213495259-9a817dc5-0ba9-485e-a9ac-5b2d94a24e13.png">
(mouse over the 1st mastodon icon displays the custom link title)

Best ^^