### PR TITLE
fix the bug that the navigation links does not appear when sliding to…

### DIFF
--- a/source/js/main.js
+++ b/source/js/main.js
@@ -59,7 +59,7 @@ $(document).ready(function() {
         var topDistance = menu.offset().top;
 
         // hide only the navigation links on desktop
-        if (!nav.is(":visible") && topDistance < 50) {
+        if (!nav.is(":visible") && topDistance < 100) {
           nav.show();
         } else if (nav.is(":visible") && topDistance > 100) {
           nav.hide();


### PR DESCRIPTION
fix the bug that the navigation links does not appear when sliding to the top.

This BUG appears in the Demo website.

When I swipe the page down, and then swipe the page to the top, the navigation links doesn't appear.