### PR TITLE
Remove invalid css rules

### DIFF
--- a/source/css/style.styl
+++ b/source/css/style.styl
@@ -46,13 +46,11 @@ body
   height: 100%
   background-color: $color-background
   color: $color-text
-  font-display: swap // @stylint ignore
   font-weight: 400
   font-size: $font-size
   font-family: $font-family-body
   line-height: $line-height
   text-rendering: geometricPrecision
-  flex: 1
 
   antialias()
 


### PR DESCRIPTION
`font-display` is a `@font-face` rule, and `flex` is not applied under a flex layout context. Both rules are invalid.

![image](https://user-images.githubusercontent.com/3762377/234920614-17e30202-d9a5-4bd7-acd1-fcfdc30f7803.png)
