### PR TITLE
add waline comment system support.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -180,6 +180,21 @@ utterances:
   label: Comment
   theme: github-dark
 
+# Waline
+# For more information: https://waline.js.org, https://github.com/walinejs/waline
+waline:
+  enabled: true #是否开启
+  serverURL: 'https://blog-comments-vercel-server.vercel.app' # Waline #服务端地址，我们这里就是上面部署的 Vercel 地址
+  avatar: mm # 头像风格
+  meta: [nick, mail] # 自定义评论框上面的三个输入框的内容
+  pageSize: 10 # 评论数量多少时显示分页
+  lang: zh-CN # 语言, 可选值: en, zh-cn
+  # Warning: 不要同时启用 `waline.visitor` 以及 `leancloud_visitors`.
+  visitor: false # 文章阅读统计
+  comment_count: true # 如果为 false , 评论数量只会在当前评论页面显示, 主页则不显示
+  requiredFields: [nick, mail] # 设置用户评论时必填的信息，[nick,mail]: [nick] | [nick, mail]
+  emoji: //unpkg.com/@waline/emojis@1.2.0/qq
+
 # Fill in your Google Analytics tracking ID to enable Google Analytics.
 google_analytics:
   enabled: false

--- a/layout/_partial/comments.ejs
+++ b/layout/_partial/comments.ejs
@@ -12,3 +12,8 @@
         </div>
     </div>
 <% } %>
+<% if(page.comments && theme.waline && theme.waline.enabled){ %>
+    <div class="blog-post-comments">
+        <div id="waline_thread"></div>
+    </div>
+<% } %>

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -77,4 +77,8 @@
 		</script>
 		<script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-MML-AM_CHTML' async></script>
 	<% } %>
+  <!-- Waline Comments -->
+  <% if (theme.waline.enabled){ %>
+    <link rel="stylesheet" href="https://unpkg.com/@waline/client@v2/dist/waline.css"/>
+  <% } %>
 </head>

--- a/layout/_partial/scripts.ejs
+++ b/layout/_partial/scripts.ejs
@@ -132,3 +132,49 @@
       }());
   </script>
 <% } %>
+<!-- Waline Comments -->
+<% if (theme.waline.enabled){ %>
+  <script type="module">
+    import { init } from 'https://unpkg.com/@waline/client@v2/dist/waline.mjs';
+
+    var EMOJI = ['//unpkg.com/@waline/emojis@1.2.0/weibo']
+    var META = ['nick', 'mail', 'link'];
+    var REQUIREDFIELDS = ['nick', 'mail', 'link'];
+
+    var emoji = '<%= theme.waline.emoji %>'.split(',').filter(function(item){
+      return item !== ''; // filter()返回满足不为空item
+    });
+    emoji = emoji.length == 0 ? EMOJI : emoji;
+
+    var meta = '<%= theme.waline.meta %>'.split(',').filter(function(item){
+      return META.indexOf(item) > -1; // filter()返回满足META.indexOf(item) > -1为true的item
+    });
+    meta = meta.length == 0 ? META : meta;
+
+    var requiredFields = '<%= theme.waline.requiredFields %>'.split(',').filter(function(item){
+      return REQUIREDFIELDS.indexOf(item) > -1; // filter()返回满足META.indexOf(item) > -1为true的item
+    });
+    requiredFields = requiredFields.length == 0 ? REQUIREDFIELDS : requiredFields;
+
+    init({
+      el: '#waline_thread',
+      serverURL: '<%= theme.waline.serverURL %>', // Waline 的服务端地址
+      path: '<%= theme.waline.path %>' == '' ? window.location.pathname : '<%= theme.waline.path %>', // 当前文章页路径，用于区分不同的文章页，以保证正确读取该文章页下的评论列表
+      lang: '<%= theme.waline.lang %>' == '' ? 'zh-CN' : '<%= theme.waline.lang %>', // 多语言支持，未设置默认英文
+      emoji: emoji,
+      dark: '<%= theme.waline.dark %>', // 暗黑模式适配
+      commentSorting: '<%= theme.waline.commentSorting %>' == '' ? 'latest' : '<%= theme.waline.commentSorting %>', // 评论列表排序方式
+      meta: meta, // 评论者相关属性
+      requiredFields: requiredFields, // 设置必填项，默认匿名
+      login: '<%= theme.waline.login %>', // 登录模式状态
+      wordLimit: '<%= theme.waline.wordLimit %>', // 评论字数限制
+      pageSize: '<%= theme.waline.pageSize %>' == '' ? 10 : '<%= theme.waline.pageSize %>', // 评论列表分页，每页条数
+      imageUploader: '<%= theme.waline.imageUploader %>', // 自定义图片上传方法
+      highlighter: '<%= theme.waline.highlighter %>', // 代码高亮
+      placeholder: '<%= theme.waline.placeholder %>',
+      avatar: '<%= theme.waline.avatar %>',
+      visitor: '<%= theme.waline.visitor %>',
+      comment_count: '<%= theme.waline.comment_count %>',
+    });
+  </script>
+<% } %>


### PR DESCRIPTION
Add Waline comment system support.

Preview :
![image](https://github.com/probberechts/hexo-theme-cactus/assets/58685598/334fe419-5f29-4e63-a5d5-46b932028a23)

but when the theme switches to dark mode, the color of waline doesn't change. The solution is add code  as follows to themes\cactus\source\css_partial\comments.styl file:
```
:root {
  /* 常规颜色 */
  --waline-white: #000 !important;
  --waline-light-grey: #666 !important;
  --waline-dark-grey: #999 !important;

  /* 布局颜色 */
  --waline-color: #888 !important;
  --waline-bgcolor: #1e1e1e !important;
  --waline-bgcolor-light: #272727 !important;
  --waline-border-color: #333 !important;
  --waline-disable-bgcolor: #444 !important;
  --waline-disable-color: #272727 !important;

  /* 特殊颜色 */
  --waline-bq-color: #272727 !important;

  /* 其他颜色 */
  --waline-info-bgcolor: #272727 !important;
  --waline-info-color: #666 !important;
}
```

Preview:
![image](https://github.com/probberechts/hexo-theme-cactus/assets/58685598/13d04867-3cd7-4842-97a7-a15cf5836cf9)

